### PR TITLE
Performance improvement on OrderedDict

### DIFF
--- a/collections2/dicts.py
+++ b/collections2/dicts.py
@@ -75,3 +75,8 @@ class OrderedDict(MutableMapping):
             return False
 
         return self.items() == other.items()
+
+    def keys(self):
+        """Return a copy of the _keys list instead of iterating over it as the MutableMapping does by default.
+        """
+        return list(self._keys)


### PR DESCRIPTION
This change improves the speed of individual keys() calls to OrderedDict by a factor of 4.
